### PR TITLE
COMMERCE-9851 - Promotion's plus button title is not correct

### DIFF
--- a/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/display/context/CommercePriceListDisplayContext.java
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/display/context/CommercePriceListDisplayContext.java
@@ -260,20 +260,40 @@ public class CommercePriceListDisplayContext
 		return commercePriceList.getParentCommercePriceListId();
 	}
 
-	public CreationMenu getPriceListCreationMenu() throws Exception {
+	public CreationMenu getPriceListCreationMenu(String portletName)
+		throws Exception {
+
 		CreationMenu creationMenu = new CreationMenu();
 
 		if (hasPermission(
 				CommercePriceListActionKeys.ADD_COMMERCE_PRICE_LIST)) {
 
-			creationMenu.addDropdownItem(
-				dropdownItem -> {
-					dropdownItem.setHref(getAddCommercePriceListRenderURL());
-					dropdownItem.setLabel(
-						LanguageUtil.get(
-							httpServletRequest, "create-new-price-list"));
-					dropdownItem.setTarget("modal-lg");
-				});
+			if (portletName.equals(
+					CommercePricingPortletKeys.COMMERCE_PRICE_LIST)) {
+
+				creationMenu.addDropdownItem(
+					dropdownItem -> {
+						dropdownItem.setHref(
+							getAddCommercePriceListRenderURL());
+						dropdownItem.setLabel(
+							LanguageUtil.get(
+								httpServletRequest, "create-new-price-list"));
+						dropdownItem.setTarget("modal-lg");
+					});
+			}
+			else if (portletName.equals(
+						CommercePricingPortletKeys.COMMERCE_PROMOTION)) {
+
+				creationMenu.addDropdownItem(
+					dropdownItem -> {
+						dropdownItem.setHref(
+							getAddCommercePriceListRenderURL());
+						dropdownItem.setLabel(
+							LanguageUtil.get(
+								httpServletRequest, "create-new-promotion"));
+						dropdownItem.setTarget("modal-lg");
+					});
+			}
 		}
 
 		return creationMenu;

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_price_lists/view.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_price_lists/view.jsp
@@ -28,7 +28,7 @@ CommercePriceListDisplayContext commercePriceListDisplayContext = (CommercePrice
 
 		<frontend-data-set:headless-display
 			apiURL="<%= commercePriceListDisplayContext.getPriceListsApiUrl(portletName) %>"
-			creationMenu="<%= commercePriceListDisplayContext.getPriceListCreationMenu() %>"
+			creationMenu="<%= commercePriceListDisplayContext.getPriceListCreationMenu(portletName) %>"
 			fdsActionDropdownItems="<%= commercePriceListDisplayContext.getPriceListFDSActionDropdownItems() %>"
 			formName="fm"
 			id="<%= CommercePricingFDSNames.PRICE_LISTS %>"


### PR DESCRIPTION
The problem was caused because both Promotions and Price Lists pages shares the same [function](https://github.com/liferay/liferay-portal/blob/d6a9ec00ce6550a7da94751d637278935c058fc0/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/display/context/CommercePriceListDisplayContext.java#L263) to create the menu, and consequently, the same button to add a content.
The proposed fix is build a structure to check which page is being shown to the user, and to add a title to the button accordingly to it.

Related ticket: [COMMERCE-9851](https://issues.liferay.com/browse/COMMERCE-9851)