### PR TITLE
COMMERCE-10541 - Subscription type is missing from the subscription length in Delivery Subscription

### DIFF
--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp
@@ -41,8 +41,8 @@ int deliverySubscriptionLength = BeanParamUtil.getInteger(cpDefinition, request,
 String deliverySubscriptionType = BeanParamUtil.getString(cpDefinition, request, "deliverySubscriptionType", defaultCPSubscriptionType);
 long deliveryMaxSubscriptionCycles = BeanParamUtil.getLong(cpDefinition, request, "deliveryMaxSubscriptionCycles");
 
-String defaultCPSubscriptionTypeLabel = StringPool.BLANK;
-String defaultDeliveryCPSubscriptionTypeLabel = StringPool.BLANK;
+String defaultCPSubscriptionTypeLabel = LanguageUtil.get(request, "day");
+String defaultDeliveryCPSubscriptionTypeLabel = LanguageUtil.get(request, "day");
 
 CPSubscriptionType cpSubscriptionType = cpDefinitionSubscriptionInfoDisplayContext.getCPSubscriptionType(subscriptionType);
 CPSubscriptionType deliveryCPSubscriptionType = cpDefinitionSubscriptionInfoDisplayContext.getCPSubscriptionType(deliverySubscriptionType);


### PR DESCRIPTION
This bug is happening because the initial value of [defaultCPSubscriptionTypeLabel](https://github.com/liferay/liferay-portal/blob/8618a3437b6fca76e6f909e8aad4fe0b17da0649/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp#L44) and [defaultDeliveryCPSubscriptionTypeLabeland](https://github.com/liferay/liferay-portal/blob/8618a3437b6fca76e6f909e8aad4fe0b17da0649/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp#L45) is blank.
At the first moment you open the page, the suffix shows the default value, which is blank, so basically it's not being shown, but after you select a Subscription Type, the value will be changed and the issue stops reproducing.
Since the default Subscription Type is always 'Day' when you open the page and stops occurring after you select any other option, my proposed fix is to pass the 'Day' language key as a default for the variables.

Related issue: [COMMERCE-10541](https://issues.liferay.com/browse/COMMERCE-10541)
This solution also fix [COMMERCE-9790](http://commerce-9790/)