### PR TITLE
COMMERCE-10562 - Name of value is not showing correctly

### DIFF
--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/edit_cp_option_value.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/edit_cp_option_value.jsp
@@ -39,7 +39,7 @@ if (cpOptionValue != null) {
 <portlet:actionURL name="/cp_options/edit_cp_option_value" var="editProductOptionValueActionURL" />
 
 <liferay-frontend:side-panel-content
-	title='<%= LanguageUtil.format(request, "edit-x", cpOptionValue.getName(), false) %>'
+	title='<%= LanguageUtil.format(request, "edit-x", cpOptionValue.getNameCurrentValue(), false) %>'
 >
 	<aui:form action="<%= editProductOptionValueActionURL %>" method="post" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= (cpOptionValue == null) ? Constants.ADD : Constants.UPDATE %>" />


### PR DESCRIPTION
The issue was caused because the [page title](https://github.com/liferay/liferay-portal/blob/615f7d1bb15b9bb39be46931531e0b1f2fd883fa/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/edit_cp_option_value.jsp#L42) was being set with the wrong function.
Proposed fix is to change the function from cpOptionValue.getName() to cpOptionValue.getNameCurrentValue(), returning the right name instead

Related issue: [COMMERCE-10562](https://issues.liferay.com/browse/COMMERCE-10562)