### PR TITLE
COMMERCE-10561 - Hover on plus icon button for Values is not correctly translated

### DIFF
--- a/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/CPOptionDisplayContext.java
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/java/com/liferay/commerce/product/options/web/internal/display/context/CPOptionDisplayContext.java
@@ -201,7 +201,9 @@ public class CPOptionDisplayContext {
 					).setWindowState(
 						LiferayWindowState.POP_UP
 					).buildString());
-				dropdownItem.setLabel("add-option-value-template");
+				dropdownItem.setLabel(
+					LanguageUtil.get(
+						cpRequestHelper.getRequest(), "add-option-value"));
 				dropdownItem.setTarget("modal");
 			}
 		).build();


### PR DESCRIPTION
The issue was occurring because "add-option-value-template" was not being passed as a language key.
Proposed fix is to pass it as a language key and change to "add-option-value" instead to be according with the [option value creation page](https://github.com/liferay/liferay-portal/blob/615f7d1bb15b9bb39be46931531e0b1f2fd883fa/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/option/add_cp_option_value.jsp#L24).

Related ticket: [COMMERCE-10561](https://issues.liferay.com/browse/COMMERCE-10561)