### PR TITLE
COMMERCE-9741 - Subscription Text is not aligned with the other text in a single SKU product details

### DIFF
--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/view.jsp
@@ -140,7 +140,7 @@ long cpDefinitionId = cpCatalogEntry.getCPDefinitionId();
 
 			<p class="mt-3 product-description"><%= HtmlUtil.escape(cpCatalogEntry.getShortDescription()) %></p>
 
-			<h4 class="commerce-subscription-info mt-3">
+			<h4 class="col commerce-subscription-info mt-3">
 				<c:if test="<%= cpSku != null %>">
 					<commerce-ui:product-subscription-info
 						CPInstanceId="<%= cpSku.getCPInstanceId() %>"


### PR DESCRIPTION
The text was not aligned because the h4 element had no padding.
Proposed fix is to add the "col" class which gives it the same properties as the other elements, including padding.